### PR TITLE
fix for poolID logic

### DIFF
--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -222,11 +222,15 @@ BlockController.prototype.transformBlock = function(block, info, reward, transac
   var poolAddress;
 
   if (transaction) {
-    transaction.outputs.forEach(function (output) {
-        if (output.satoshis > (reward * 0.8)) {
-            poolAddress = output.address;
-        }
-    });
+	  var largest = 0;
+    var winner;
+	  transaction.outputs.forEach(function (output) {
+       if (output.satoshis > largest) {
+            winner = output.address;
+			      largest = output.satoshis;
+       }
+	  });
+    poolAddress = winner;
   }
 
   return {

--- a/services/StatisticService.js
+++ b/services/StatisticService.js
@@ -1235,10 +1235,12 @@ StatisticService.prototype.getBlockRewardr = function(height) {
 StatisticService.prototype.getPoolInfo = function(paddress) {
 
   for(var k in this.poolStrings) {
+		if (paddress) {
     if (paddress.toString().match(k)) {
       this.poolStrings[k].address = paddress;
 	  return this.poolStrings[k];
     }
+		}
   }
 
   return {};


### PR DESCRIPTION
 accurately assign a minedby address to the largest satoshi value recipient in the coinbase, in the situations where non standard coinbase transactions exist, such as block 761046